### PR TITLE
Bug 1109 snapshot slave unit test fail

### DIFF
--- a/.github/workflows/Development.yml
+++ b/.github/workflows/Development.yml
@@ -2,7 +2,7 @@ name: Development
 
 on:
   push:
-    branches: [ US_1103_CreateSWArchitectureDocumentation ]
+    branches: [ BUG_1109_SnapshotSlaveUnitTestFail ]
 
 jobs:
   call_BuildTest:

--- a/include/eros/SnapshotNode/SnapshotProcess.h
+++ b/include/eros/SnapshotNode/SnapshotProcess.h
@@ -3,6 +3,7 @@
 #ifndef SnapshotProcess_H
 #define SnapshotProcess_H
 #include <eros/BaseNodeProcess.h>
+#include <eros/Utility.h>
 #include <tinyxml.h>
 
 #include <boost/thread.hpp>

--- a/include/eros/Utility.h
+++ b/include/eros/Utility.h
@@ -3,6 +3,7 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
+#include <eros/file.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -27,5 +28,7 @@ struct ExecResult {
   \return The result of the command
 */
 ExecResult exec(const char* cmd, bool wait_for_result);
+
+std::string pretty(eros::file msg);
 }  // namespace eros
 #endif  // UTILITY_H

--- a/nodes/SnapshotNode/CMakeLists.txt
+++ b/nodes/SnapshotNode/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Commenting out for now
-#add_library(snapshotProcess SnapshotProcess.cpp)
-#target_link_libraries(snapshotProcess ${catkin_LIBRARIES} ${TinyXML_LIBRARIES} baseNodeProcess)
+add_library(snapshotProcess SnapshotProcess.cpp)
+target_link_libraries(snapshotProcess ${catkin_LIBRARIES} ${TinyXML_LIBRARIES} baseNodeProcess utility)
 
-#add_executable(snapshot_node SnapshotNode.cpp) 
-#target_link_libraries(snapshot_node ${catkin_LIBRARIES} ${TinyXML_LIBRARIES} ${Boost_LIBRARIES} snapshotProcess baseNode )
-#add_dependencies(snapshot_node ${eros_EXPORTED_TARGETS})
-#add_subdirectory(test)
+add_executable(snapshot_node SnapshotNode.cpp) 
+target_link_libraries(snapshot_node ${catkin_LIBRARIES} ${TinyXML_LIBRARIES} ${Boost_LIBRARIES} snapshotProcess baseNode )
+add_dependencies(snapshot_node ${eros_EXPORTED_TARGETS})
+add_subdirectory(test)

--- a/nodes/SnapshotNode/SnapshotNode.cpp
+++ b/nodes/SnapshotNode/SnapshotNode.cpp
@@ -281,7 +281,7 @@ bool SnapshotNode::run_1hz() {
         process->get_latest_diagnostics();
     for (std::size_t i = 0; i < latest_diagnostics.size(); ++i) {
         logger->log_diagnostic(latest_diagnostics.at(i));
-        diagnostic_pub.publish(process->convert(latest_diagnostics.at(i)));
+        diagnostic_pub.publish(BaseNodeProcess::convert(latest_diagnostics.at(i)));
     }
     Diagnostic::DiagnosticDefinition diag = process->get_root_diagnostic();
     if (process->get_nodestate() == Node::State::RESET) {
@@ -330,7 +330,7 @@ bool SnapshotNode::run_10hz() {
         state.diag.DiagnosticMessage = (uint8_t)Diagnostic::Message::NOERROR;
         state.PercentComplete = process->get_snapshotprogress_percentage();
         if (state.diag.Level > (uint8_t)Level::Type::NOTICE) {
-            logger->log_diagnostic(process->convert(state.diag));
+            logger->log_diagnostic(BaseNodeProcess::convert(state.diag));
         }
         commandstate_pub.publish(state);
     }

--- a/nodes/SnapshotNode/test/test_snapshotNode_Master.cpp
+++ b/nodes/SnapshotNode/test/test_snapshotNode_Master.cpp
@@ -17,7 +17,7 @@ void commandstate_Callback(const eros::command_state& msg) {
 TEST(SnapshotNode, TestMaster) {
     ros::NodeHandle nh("~");
     Logger* logger = new Logger("DEBUG", "test_SnapshotNode");
-
+    logger->enable_ROS_logger();
     std::string heartbeat_topic = "/test/snapshot_node/heartbeat";
     ros::Subscriber sub = nh.subscribe(heartbeat_topic, 100, &heartbeat_Callback);
     sleep(5.0);

--- a/nodes/SnapshotNode/test/test_snapshotNode_Slave.cpp
+++ b/nodes/SnapshotNode/test/test_snapshotNode_Slave.cpp
@@ -18,7 +18,7 @@ TEST(SnapshotNode, TestMaster) {
     int TEST_COUNT = 5;
     int TEST_PASS_REQUIRED_COUNT = 1;
     int tests_passed = 0;
-    Logger* logger = new Logger("DEBUG", "test_SnapshotNode");
+    Logger* logger = new Logger("DEBUG", "tester_SnapshotNode");
     for (int i = 0; i < TEST_COUNT; ++i) {
         bool ok = true;
         logger->log_info("Test iteration: " + std::to_string(i) + "/" + std::to_string(TEST_COUNT));
@@ -126,7 +126,7 @@ TEST(SnapshotNode, TestMaster) {
 }
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
-    ros::init(argc, argv, "test_snapshotNode");
+    ros::init(argc, argv, "tester_snapshotNode");
     ros::AsyncSpinner spinner(1);
     spinner.start();
     int ret = RUN_ALL_TESTS();

--- a/nodes/SnapshotNode/test/test_snapshotNode_Slave.cpp
+++ b/nodes/SnapshotNode/test/test_snapshotNode_Slave.cpp
@@ -19,9 +19,10 @@ TEST(SnapshotNode, TestMaster) {
     int TEST_PASS_REQUIRED_COUNT = 1;
     int tests_passed = 0;
     Logger* logger = new Logger("DEBUG", "tester_SnapshotNode");
+    logger->enable_ROS_logger();
     for (int i = 0; i < TEST_COUNT; ++i) {
         bool ok = true;
-        logger->log_info("Test iteration: " + std::to_string(i) + "/" + std::to_string(TEST_COUNT));
+        logger->log_warn("Test iteration: " + std::to_string(i) + "/" + std::to_string(TEST_COUNT));
         heartbeat_count = 0;
         commandstate_count = 0;
         ros::NodeHandle nh("~");
@@ -42,7 +43,7 @@ TEST(SnapshotNode, TestMaster) {
         EXPECT_TRUE(heartbeat_count > 0);
 
         eros::command snapshot_command;
-        logger->log_notice("Testing Clearing of Snapshots.");
+        logger->log_warn("Testing Clearing of Snapshots.");
         snapshot_command.Command = (uint8_t)eros::Command::Type::GENERATE_SNAPSHOT;
         snapshot_command.Option1 =
             (uint8_t)eros::Command::GenerateSnapshot_Option1::CLEAR_SNAPSHOTS;
@@ -56,7 +57,7 @@ TEST(SnapshotNode, TestMaster) {
              (uint8_t)eros::Command::GenerateSnapshot_Option1::CLEAR_SNAPSHOTS) &&
             (commandstate_msg.diag.DiagnosticMessage == (uint8_t)Diagnostic::Message::NOERROR)) {}
         else {
-            logger->log_warn("Clear Command Failed!");
+            logger->log_error("Clear Command Failed!");
             ok = false;
         }
         usleep(2.0 * 1000000.0);
@@ -68,7 +69,7 @@ TEST(SnapshotNode, TestMaster) {
         EXPECT_TRUE(req.response.files.size() == 0);
         commandstate_count = 0;
 
-        logger->log_notice("Testing Generation of Snapshot");
+        logger->log_warn("Testing Generation of Snapshot");
         snapshot_command.Command = (uint8_t)eros::Command::Type::GENERATE_SNAPSHOT;
         snapshot_command.Option1 = (uint8_t)eros::Command::GenerateSnapshot_Option1::RUN_SLAVE;
         command_pub.publish(snapshot_command);
@@ -81,7 +82,7 @@ TEST(SnapshotNode, TestMaster) {
              (uint8_t)eros::Command::GenerateSnapshot_Option1::RUN_SLAVE) &&
             (commandstate_msg.diag.DiagnosticMessage == (uint8_t)Diagnostic::Message::NOERROR)) {}
         else {
-            logger->log_warn("Gen Snap for Slave Command Failed!");
+            logger->log_error("Gen Snap for Slave Command Failed!");
             ok = false;
         }
 
@@ -89,18 +90,18 @@ TEST(SnapshotNode, TestMaster) {
 
         req.response.files.clear();
         if (client.call(req) == false) {
-            logger->log_warn("Snap Command for Client Failed!");
+            logger->log_error("Snap Command for Client Failed!");
             ok = false;
         }
         if ((req.response.files.size() == 1) == false) {
-            logger->log_warn("Snap Response Had no Files!");
+            logger->log_error("Snap Response Had no Files!");
             ok = false;
         }
         for (std::size_t i = 0; i < req.response.files.size(); ++i) {
             if ((req.response.files.at(i).status == (uint8_t)FileHelper::FileStatus::FILE_OK) &&
                 (req.response.files.at(i).data_length > 0)) {}
             else {
-                logger->log_warn("Snap File Missing!");
+                logger->log_error("Snap File Missing!");
                 ok = false;
             }
             /*
@@ -115,10 +116,10 @@ TEST(SnapshotNode, TestMaster) {
         }
         if (ok == true) {
             tests_passed++;
-            logger->log_notice("Snap Test: " + std::to_string(i + 1) + " Passed!");
+            logger->log_warn("Snap Test: " + std::to_string(i + 1) + " Passed!");
         }
         else {
-            logger->log_warn("Snap Test: " + std::to_string(i + 1) + " Failed!");
+            logger->log_error("Snap Test: " + std::to_string(i + 1) + " Failed!");
         }
     }
     EXPECT_TRUE(tests_passed >= TEST_PASS_REQUIRED_COUNT);

--- a/nodes/SnapshotNode/test/test_snapshotNode_Slave.test
+++ b/nodes/SnapshotNode/test/test_snapshotNode_Slave.test
@@ -4,7 +4,7 @@
         <node name="snapshot_node" pkg="eros" type="snapshot_node"  output="screen" clear_params="true">
             <param name="robot_namespace" value="test"/>
             <param name="startup_delay"       value="0.0"/>
-            <param name="verbosity_level"       value="DEBUG"/>
+            <param name="verbosity_level"       value="INFO"/>
             <param name="require_pps_to_start"  value="false"/>    
             <param name="loop1_rate"            value="1"/> 
             <param name="loop2_rate"            value="10"/>

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -45,6 +45,12 @@ US: 1097 Update basic scripts to support ROS Noetic
 
 --- Bugs
 
+BUG: 1109 Intermittent Snapshot Node Slave Unit Test Fails
+  Author: David Gitz
+  Date: 12-Oct-2022
+  * Found root cause of bug, not filtering out zero length file names in list query.
+  * Resolves Issue https://github.com/dgitz/eros/issues/204
+
 --- Other Comments
 * This release is intended to migrate to ROS Noetic.
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -5,6 +5,13 @@ Author: David Gitz
 Date: TBD
 
 --- User Stories
+US: 1110 Create Release Test Plan
+  Author: David Gitz
+  Date: 11-Oct-2022
+  * Created SW Release Plan
+  * Updated Wiki
+  * Added Regression tool in Dev Tools script.
+
 US: 1103 Add SW Architecture Documentation
   Author: David Gitz
   Date: 9-Oct-2022

--- a/src/BaseNodeProcess.cpp
+++ b/src/BaseNodeProcess.cpp
@@ -344,12 +344,12 @@ std::vector<std::string> BaseNodeProcess::get_files_indir(std::string dir) {
     ExecResult execResult = exec(ls_cmd.c_str(), true);
     std::string res = execResult.Result;
     boost::split(files, res, boost::is_any_of("\n"), boost::token_compress_on);
-    if (files.size() > 0) {
-        if (files.at(0).size() == 0) {
-            // No way practically to unit test.
-            // LCOV_EXCL_START
-            files.erase(files.begin());
-            // LCOV_EXCL_STOP
+    for (std::vector<std::string>::iterator it = files.begin(); it != files.end();) {
+        if (it->size() == 0) {
+            it = files.erase(it);
+        }
+        else {
+            ++it;
         }
     }
     return files;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(utility Utility.cpp)
 target_link_libraries(utility ${catkin_LIBRARIES})
+add_dependencies(utility eros_generate_messages_cpp)
 
 add_library(logger Logger.cpp)
 target_link_libraries(logger ${catkin_LIBRARIES})

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -59,4 +59,13 @@ ExecResult exec(const char *cmd, bool wait_for_result) {
     }
 }
 // LCOV_EXCL_STOP
+
+std::string pretty(eros::file msg) {
+    std::string str;
+    str = "File: " + msg.file_name;
+    str += " Length: " + std::to_string(msg.data_length);
+    str += " Extension Type: " + std::to_string(msg.extension_type);
+    str += " Status: " + std::to_string(msg.status);
+    return str;
+}
 }  // namespace eros

--- a/src/test/test_utility.cpp
+++ b/src/test/test_utility.cpp
@@ -32,6 +32,12 @@ TEST(UtilityEquality, TestCases) {
         EXPECT_FALSE(isEqual(a, b, eps));
     }
 }
+TEST(PrettyFunctions, PrettyCases) {
+    {
+        eros::file msg;
+        EXPECT_GT(pretty(msg).size(), 0);
+    }
+}
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Resolves #204 
Root cause was improper counting of files in a directory (which was used to indicate if snap zip file was present).
Enabled ROS Logger on Snapshot tests to output of unit tests would show up when run via catkin test suite.  

Validated by:
  - Running regular unit tests
  - Running Snap Slave Test with 50 Tests (instead of 5), all passed.  
  - Running in Pipeline
  - Running Regression Tests (see: https://github.com/dgitz/eros/wiki/Test-Plan)